### PR TITLE
Add mobile responsive design

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -1,6 +1,6 @@
 .gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 10px;
   padding: 0 5px;
 }
@@ -61,4 +61,13 @@
   max-height: 90vh;
   border-radius: 6px;
   box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+}
+
+
+
+@media (max-width: 480px) {
+  .gallery {
+    gap: 5px;
+    padding: 0 0px;
+  }
 }

--- a/css/blog.css
+++ b/css/blog.css
@@ -9,6 +9,7 @@
   align-items: center;
   flex-wrap: wrap;
   margin: 0.5rem 0;
+  gap: 0.2rem 0rem;
 }
 
 /* 标题的格式 */
@@ -70,12 +71,6 @@
 
 
 
-
-
-
-
-
-
 /* 增加blog间的段间距 */
 .blog-entry {
   margin: 0.6rem 0;
@@ -99,11 +94,18 @@
   margin-top: 2rem;
   margin-bottom: -0.5rem;
   font-weight: bold;
-  font-size: 2rem;
+  font-size: 1.8rem;
   color: var(--color-text-muted);
   /* border-bottom: 2px dashed var(--color-text-muted); */
 }
 
 .blog-title {
     font-weight: bold;
+}
+
+
+@media (max-width: 480px) {
+  .year-divider {
+    margin-top: 1.5rem;
+  }
 }

--- a/css/index.css
+++ b/css/index.css
@@ -15,7 +15,6 @@
 }
 
 /* 姓名和拼音 */
-
 .name-cn {
   font-family: '楷体', sans-serif;
   font-weight: bold;
@@ -30,19 +29,30 @@
   color: var(--color-text-muted);
 }
 
-/* 访客计数 */
-.counter {
-  text-align: center;
-  font-style: italic;
-  margin-top: 30px;
-}
 
 /* 访客地图 */
 .visitor-map {
   display: block;
   margin: 0 auto;
-  width: 590px;
-  height: 300px;
+
+  width: 100%;
+  max-width: 590px;
+  aspect-ratio: 590 / 300;
+
   border-radius: 5%;
 }
 
+
+/* 移动端头像变小 */
+@media (max-width: 480px) {
+  .portrait {
+    width: 120px;
+    height: 120px;
+    margin-left: 12px;
+  }
+}
+
+/* 用于移动端姓名不被换行 */
+.name-block {
+  white-space: nowrap;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -139,3 +139,36 @@ a:hover {
   transform: translate(-50%, -50%);
   z-index: -1;
 }
+
+
+
+/* 移动端适配 */
+@media (max-width: 480px) {
+  .container { /* 顶部留白减半 */
+    padding-top: 1rem;
+  }
+  body { /* 缩小了1.8的行高 */
+    line-height: 1.6;
+  }
+  h1 { /* 缩小了2em的字体, 上下间距减半 */
+    font-size: 1.6em;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+  h2 { /* 缩小了1.5em的字体 */
+    font-size: 1.3em;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+  .nav-links a { /* 导航栏更紧凑 */
+    margin-right: 0.6rem;
+  }
+  .nav-button button{
+    border: none;
+    margin-left: 0.1rem;
+  }
+  .icon {
+    width: 1.4rem;
+    height: 1.4rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -57,10 +57,11 @@
 
       <!--姓名, index.css-->
       <h1>
-        Xu Ling &nbsp;
-        <span class="name-cn">徐&thinsp;菱</span> &nbsp;
-        <span class="name-pinyin">[ɕy&thinsp;liŋ]</span>   
+        <span class="name-block">Xu&nbsp;Ling</span> &nbsp;
+        <span class="name-block name-cn">徐&thinsp;菱</span> &nbsp;
+        <span class="name-block name-pinyin">[ɕy&thinsp;liŋ]</span>
       </h1>
+
 
       <!--邮箱, 非标准格式直接定义在html里-->
       <p> 
@@ -171,7 +172,8 @@
 
     <!--脚注, 只有index的需要更新update时间, style.css-->
     <footer class="site-footer">
-        &copy; 2025 Xu Ling. All rights reserved. Updated Dec 2025.
+        &copy; 2025 Xu Ling. All rights reserved. <br>
+        Updated Dec 2025.
     </footer>
 
   </div>

--- a/js/background.js
+++ b/js/background.js
@@ -8,16 +8,16 @@ let animationId = null;
 let backgroundEnabled = localStorage.getItem("backgroundEnabled") !== "false"; // 背景是否启用
 
 
-// 此处0.7*size可以改变画框大小
+// 此处0.7*size可以改变画框大小 (后改为1)
 function resizeCanvas() {
   const size = Math.min(window.innerWidth, window.innerHeight);
   const maxCanvasSize = 600;
 
-  canvas.width = Math.min(size * 0.7, maxCanvasSize);
-  canvas.height = Math.min(size * 0.7, maxCanvasSize);
+  canvas.width = Math.min(size * 1, maxCanvasSize);
+  canvas.height = Math.min(size * 1, maxCanvasSize);
 
-  canvas.style.width = `${size * 0.7}px`;
-  canvas.style.height = `${size * 0.7}px`;
+  canvas.style.width = `${size * 1}px`;
+  canvas.style.height = `${size * 1}px`;
 }
 resizeCanvas();
 window.addEventListener("resize", resizeCanvas);

--- a/js/blog.js
+++ b/js/blog.js
@@ -183,7 +183,7 @@ function renderList() {
     el.classList.add("blog-entry");
     el.innerHTML = `
       <a href="${item.file}" target="_blank" class="blog-title">${item.title}</a>
-      <span class="meta">${item.pages} pages, ${formatDate(item.date)}</span>
+      <span class="meta">${item.pages} pp. ${formatDate(item.date)}</span>
       <span class="tags">#${item.language} #${item.category}</span>
     `;
     container.appendChild(el);


### PR DESCRIPTION
#### Dec. 17
* style.css缩小了全局的部分间距, 使导航栏更紧凑, 能够安排在一行内
* background.js中动态背景的canvas改为1width, 原本是0.7width
* index.css缩小了头像, 配合修改index.html使得移动端姓名nowrap, 加入了访客地图自适应宽度
* blog.css添加了tags按钮的行间距, 使得移动端的tags不会上下粘连
* blog.js中pages改为pp.看起来更简短
* about.css中修改gallery排布为固定4张图片, 缩小移动端间距, 且由于没有hover行为去掉了padding